### PR TITLE
#53 - 헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB) 

### DIFF
--- a/src/main/resources/Procfile
+++ b/src/main/resources/Procfile
@@ -1,1 +1,0 @@
-web: java $JAVA_OPTS -Dserver.port=$PORT -Dspring.profiles.active=heroku -jar build/libs/project-board-v1.1.jar

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
조사해본 결과, cleardb 의 기본 mysql 버전이 `5.6`
너무 낮기 때문에 대안으로 jawsdb 를 찾아냄
기본 mysql 버전 `8.0`
이를 이용해 환경변수를 다시 작업함

This fixes #53 

* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedi